### PR TITLE
fix: update terms canonical link

### DIFF
--- a/public/terms.html
+++ b/public/terms.html
@@ -8,20 +8,15 @@
         <!-- SEO Meta Tags -->
         <meta name="description" content="Read Ozran Secure Shield's Terms of Service. Learn about our cybersecurity training platform policies and user agreements.">
         <meta name="robots" content="index, follow">
-        <link rel="canonical" href="https://ozran.net.com/terms.html">
-        
+        <link rel="canonical" href="https://ozran.net/terms.html">
+
         <!-- Favicon -->
         <link rel="icon" type="image/x-icon" href="/favicon.ico">
-        
+
         <!-- Your CSS links -->
         <link rel="stylesheet" href="index.css">
-        <!-- ... rest of your head content -->
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Terms of Service - Ozran Secure Shield</title>
-    <link rel="stylesheet" href="index.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <style>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+        <style>
         .legal-page {
             padding: 8rem 0 4rem;
             background: var(--bg-primary);


### PR DESCRIPTION
## Summary
- correct canonical URL for terms page
- tidy head by removing duplicate meta and title tags

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689bb22837788330b9389c61ec5d43d7