### PR TITLE
Use double quotes in newsletter notification

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -432,7 +432,7 @@ function handleNewsletterSubmit(e) {
     const email = e.target.querySelector('input[type="email"]').value;
     
     // Simulate API call
-    showNotification('Thanks for subscribing! We\'ll keep you updated.', 'success');
+    showNotification("Thanks for subscribing! We'll keep you updated.", "success");
     e.target.reset();
 }
 


### PR DESCRIPTION
## Summary
- fix newsletter subscription notification quoting

## Testing
- `node --check public/index.js`


------
https://chatgpt.com/codex/tasks/task_e_689bb22bf61c83309785c5ef38f412c2