### PR TITLE
Replace placeholder API references with static placeholders

### DIFF
--- a/public/auth.html
+++ b/public/auth.html
@@ -385,7 +385,7 @@
                         <p>"Ozran reduced our security incidents by 85% in just 6 months."</p>
                     </div>
                     <div class="testimonial-author">
-                        <img src="/api/placeholder/40/40" alt="Sarah Johnson">
+                        <img src="https://via.placeholder.com/40" alt="Sarah Johnson">
                         <div>
                             <div class="author-name">Sarah Johnson</div>
                             <div class="author-title">CISO, TechCorp</div>

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -109,7 +109,7 @@
                 
                 <div class="user-menu">
                     <button class="user-menu-trigger" onclick="toggleUserMenu()">
-                        <img src="/api/placeholder/40/40" alt="User Avatar" class="user-avatar">
+                        <img src="https://via.placeholder.com/40" alt="User Avatar" class="user-avatar">
                         <span class="user-name" id="userName">John Doe</span>
                         <i class="fas fa-chevron-down"></i>
                     </button>
@@ -408,7 +408,7 @@
                                     </td>
                                     <td>
                                         <div class="employee-info">
-                                            <img src="/api/placeholder/40/40" alt="Sarah Wilson" class="employee-avatar">
+                                            <img src="https://via.placeholder.com/40" alt="Sarah Wilson" class="employee-avatar">
                                             <div class="employee-details">
                                                 <div class="employee-name">Sarah Wilson</div>
                                                 <div class="employee-email">sarah.wilson@company.com</div>
@@ -456,7 +456,7 @@
                                     </td>
                                     <td>
                                         <div class="employee-info">
-                                            <img src="/api/placeholder/40/40" alt="Michael Johnson" class="employee-avatar">
+                                            <img src="https://via.placeholder.com/40" alt="Michael Johnson" class="employee-avatar">
                                             <div class="employee-details">
                                                 <div class="employee-name">Michael Johnson</div>
                                                 <div class="employee-email">michael.johnson@company.com</div>
@@ -504,7 +504,7 @@
                                     </td>
                                     <td>
                                         <div class="employee-info">
-                                            <img src="/api/placeholder/40/40" alt="Emily Davis" class="employee-avatar">
+                                            <img src="https://via.placeholder.com/40" alt="Emily Davis" class="employee-avatar">
                                             <div class="employee-details">
                                                 <div class="employee-name">Emily Davis</div>
                                                 <div class="employee-email">emily.davis@company.com</div>
@@ -552,7 +552,7 @@
                                     </td>
                                     <td>
                                         <div class="employee-info">
-                                            <img src="/api/placeholder/40/40" alt="David Brown" class="employee-avatar">
+                                            <img src="https://via.placeholder.com/40" alt="David Brown" class="employee-avatar">
                                             <div class="employee-details">
                                                 <div class="employee-name">David Brown</div>
                                                 <div class="employee-email">david.brown@company.com</div>
@@ -1129,7 +1129,7 @@
                     <div class="profile-sidebar">
                         <div class="profile-card">
                             <div class="profile-avatar-section">
-                                <img src="/api/placeholder/120/120" alt="Profile Avatar" class="profile-avatar">
+                                <img src="https://via.placeholder.com/120" alt="Profile Avatar" class="profile-avatar">
                                 <button class="avatar-upload-btn">
                                     <i class="fas fa-camera"></i>
                                 </button>

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -57,7 +57,7 @@ function loadSampleData() {
                 riskLevel: 'high',
                 trainingProgress: 75,
                 lastActivity: '2 days ago',
-                avatar: '/api/placeholder/40/40'
+                avatar: 'https://via.placeholder.com/40'
             },
             {
                 id: 2,
@@ -68,7 +68,7 @@ function loadSampleData() {
                 riskLevel: 'low',
                 trainingProgress: 100,
                 lastActivity: '1 day ago',
-                avatar: '/api/placeholder/40/40'
+                avatar: 'https://via.placeholder.com/40'
             },
             {
                 id: 3,
@@ -79,7 +79,7 @@ function loadSampleData() {
                 riskLevel: 'medium',
                 trainingProgress: 60,
                 lastActivity: '3 days ago',
-                avatar: '/api/placeholder/40/40'
+                avatar: 'https://via.placeholder.com/40'
             },
             {
                 id: 4,
@@ -90,7 +90,7 @@ function loadSampleData() {
                 riskLevel: 'medium',
                 trainingProgress: 90,
                 lastActivity: '5 days ago',
-                avatar: '/api/placeholder/40/40'
+                avatar: 'https://via.placeholder.com/40'
             }
         ],
         campaigns: [
@@ -915,7 +915,7 @@ function handleAddEmployee(event) {
         id: sampleData.employees.length + 1,
         ...employeeData,
         riskLevel: employeeData.riskScore > 70 ? 'high' : employeeData.riskScore > 40 ? 'medium' : 'low',
-        avatar: '/api/placeholder/40/40'
+        avatar: 'https://via.placeholder.com/40'
     });
     
     // Refresh table

--- a/public/index.html
+++ b/public/index.html
@@ -418,7 +418,7 @@
                         <p>"Ozran transformed our security culture completely. Our phishing susceptibility dropped by 85% in just 6 months, and employee engagement with security training increased dramatically."</p>
                     </div>
                     <div class="testimonial-author">
-                        <img src="/api/placeholder/60/60" alt="Sarah Johnson" class="author-avatar">
+                        <img src="https://via.placeholder.com/60" alt="Sarah Johnson" class="author-avatar">
                         <div class="author-info">
                             <div class="author-name">Sarah Johnson</div>
                             <div class="author-title">CISO, TechCorp Industries</div>
@@ -441,7 +441,7 @@
                         <p>"The analytics and reporting features give us incredible insights into our security posture. The executive dashboards make it easy to communicate security metrics to leadership."</p>
                     </div>
                     <div class="testimonial-author">
-                        <img src="/api/placeholder/60/60" alt="Michael Chen" class="author-avatar">
+                        <img src="https://via.placeholder.com/60" alt="Michael Chen" class="author-avatar">
                         <div class="author-info">
                             <div class="author-name">Michael Chen</div>
                             <div class="author-title">IT Director, Finance Plus</div>
@@ -464,7 +464,7 @@
                         <p>"Easy to deploy and manage across our global workforce. Our employees love the interactive training modules, and we've seen measurable improvements in security awareness."</p>
                     </div>
                     <div class="testimonial-author">
-                        <img src="/api/placeholder/60/60" alt="Lisa Rodriguez" class="author-avatar">
+                        <img src="https://via.placeholder.com/60" alt="Lisa Rodriguez" class="author-avatar">
                         <div class="author-info">
                             <div class="author-name">Lisa Rodriguez</div>
                             <div class="author-title">Security Manager, HealthCare Inc</div>


### PR DESCRIPTION
## Summary
- swap /api/placeholder image references for `https://via.placeholder.com` in public pages and scripts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bb2ec7d6c8330bd2917c09751c441