### PR TITLE
Add About and Contact pages with navigation and caching

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>About Us - Ozran Secure Shield</title>
+    <meta name="description" content="Learn about Ozran Secure Shield's mission to provide advanced cybersecurity training and phishing simulation.">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="stylesheet" href="index.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <style>
+        .content-page {
+            padding: 8rem 0 4rem;
+            background: var(--bg-primary);
+            min-height: 100vh;
+        }
+        .page-content {
+            max-width: 800px;
+            margin: 0 auto;
+            color: var(--text-secondary);
+            line-height: 1.8;
+        }
+        .page-content h1 {
+            color: var(--text-primary);
+            text-align: center;
+            margin-bottom: 2rem;
+        }
+    </style>
+</head>
+<body>
+    <!-- Header -->
+    <header class="header">
+        <div class="container">
+            <div class="header-container">
+                <div class="logo">
+                    <i class="fas fa-shield-alt"></i>
+                    <span>Ozran Secure Shield</span>
+                </div>
+                <nav class="nav">
+                    <ul>
+                        <li><a href="index.html#features">Features</a></li>
+                        <li><a href="index.html#pricing">Pricing</a></li>
+                        <li><a href="index.html#testimonials">Testimonials</a></li>
+                        <li><a href="about.html">About</a></li>
+                        <li><a href="contact.html">Contact</a></li>
+                    </ul>
+                </nav>
+                <div class="header-actions">
+                    <button class="btn btn-primary" onclick="window.location.href='auth.html'">Login</button>
+                    <button class="mobile-menu-btn" id="mobileMenuBtn">
+                        <i class="fas fa-bars"></i>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <!-- Mobile Navigation Overlay -->
+    <div class="mobile-nav" id="mobileNav">
+        <div class="mobile-nav-header">
+            <div class="logo">
+                <i class="fas fa-shield-alt"></i>
+                <span>Ozran Secure Shield</span>
+            </div>
+            <button class="mobile-nav-close" id="mobileNavClose">
+                <i class="fas fa-times"></i>
+            </button>
+        </div>
+        <ul class="mobile-nav-links">
+            <li><a href="index.html#features" onclick="closeMobileNav()">Features</a></li>
+            <li><a href="index.html#pricing" onclick="closeMobileNav()">Pricing</a></li>
+            <li><a href="index.html#testimonials" onclick="closeMobileNav()">Testimonials</a></li>
+            <li><a href="about.html" onclick="closeMobileNav()">About</a></li>
+            <li><a href="contact.html" onclick="closeMobileNav()">Contact</a></li>
+        </ul>
+        <div class="mobile-nav-cta">
+            <button class="btn btn-primary" onclick="window.location.href='auth.html'">Get Started</button>
+        </div>
+    </div>
+
+    <!-- About Content -->
+    <section class="content-page">
+        <div class="container">
+            <div class="page-content">
+                <h1>About Ozran Secure Shield</h1>
+                <p>Ozran Secure Shield is dedicated to strengthening your organization's human firewall through advanced phishing simulations and comprehensive security awareness training.</p>
+                <p>Our mission is to empower businesses of all sizes with the knowledge and tools needed to defend against evolving cyber threats.</p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer id="contact" class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <div class="footer-brand">
+                        <div class="logo">
+                            <i class="fas fa-shield-alt"></i>
+                            <span>Ozran Secure Shield</span>
+                        </div>
+                        <p>Protecting organizations worldwide with advanced cybersecurity training, phishing simulation, and comprehensive security awareness programs.</p>
+                        <div class="social-links">
+                            <a href="#" class="social-link"><i class="fab fa-linkedin"></i></a>
+                            <a href="#" class="social-link"><i class="fab fa-twitter"></i></a>
+                            <a href="#" class="social-link"><i class="fab fa-facebook"></i></a>
+                            <a href="#" class="social-link"><i class="fab fa-youtube"></i></a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Product</h4>
+                    <ul class="footer-links">
+                        <li><a href="index.html#features">Features</a></li>
+                        <li><a href="index.html#pricing">Pricing</a></li>
+                        <li><a href="#">Security</a></li>
+                        <li><a href="#">Integrations</a></li>
+                        <li><a href="#">API Documentation</a></li>
+                        <li><a href="#">Roadmap</a></li>
+                    </ul>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Solutions</h4>
+                    <ul class="footer-links">
+                        <li><a href="#">Enterprise</a></li>
+                        <li><a href="#">Small Business</a></li>
+                        <li><a href="#">Healthcare</a></li>
+                        <li><a href="#">Financial Services</a></li>
+                        <li><a href="#">Government</a></li>
+                        <li><a href="#">Education</a></li>
+                    </ul>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Resources</h4>
+                    <ul class="footer-links">
+                        <li><a href="#">Blog</a></li>
+                        <li><a href="#">Case Studies</a></li>
+                        <li><a href="#">Security Center</a></li>
+                        <li><a href="#">Help Center</a></li>
+                        <li><a href="#">Webinars</a></li>
+                        <li><a href="#">Training</a></li>
+                    </ul>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Company</h4>
+                    <ul class="footer-links">
+                        <li><a href="about.html">About Us</a></li>
+                        <li><a href="#">Careers</a></li>
+                        <li><a href="#">Press</a></li>
+                        <li><a href="#">Partners</a></li>
+                        <li><a href="contact.html">Contact</a></li>
+                        <li><a href="#">Events</a></li>
+                    </ul>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Legal</h4>
+                    <ul class="footer-links">
+                        <li><a href="terms.html">Terms of Service</a></li>
+                        <li><a href="privacy.html">Privacy Policy</a></li>
+                        <li><a href="#">Cookie Policy</a></li>
+                        <li><a href="#">GDPR</a></li>
+                        <li><a href="#">Compliance</a></li>
+                        <li><a href="#">Security Policy</a></li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="footer-bottom">
+                <div class="footer-bottom-content">
+                    <p>&copy; 2024 Ozran Secure Shield. All rights reserved.</p>
+                    <div class="footer-bottom-links">
+                        <a href="terms.html">Terms</a>
+                        <a href="privacy.html">Privacy</a>
+                        <a href="about.html">About</a>
+                        <a href="contact.html">Contact</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>
+

--- a/public/contact.html
+++ b/public/contact.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contact Us - Ozran Secure Shield</title>
+    <meta name="description" content="Get in touch with the Ozran Secure Shield team for support or inquiries.">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="stylesheet" href="index.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <style>
+        .content-page {
+            padding: 8rem 0 4rem;
+            background: var(--bg-primary);
+            min-height: 100vh;
+        }
+        .page-content {
+            max-width: 800px;
+            margin: 0 auto;
+            color: var(--text-secondary);
+            line-height: 1.8;
+        }
+        .page-content h1 {
+            color: var(--text-primary);
+            text-align: center;
+            margin-bottom: 2rem;
+        }
+        .contact-details {
+            text-align: center;
+        }
+        .contact-details p {
+            margin-bottom: 1rem;
+        }
+        .contact-form {
+            margin-top: 2rem;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+        .contact-form input,
+        .contact-form textarea {
+            padding: 0.75rem 1rem;
+            border: 1px solid var(--bg-secondary);
+            border-radius: 0.5rem;
+            background: var(--bg-secondary);
+            color: var(--text-primary);
+        }
+        .contact-form button {
+            align-self: flex-start;
+            padding: 0.75rem 1.5rem;
+            border: none;
+            border-radius: 0.5rem;
+            background: var(--accent-primary);
+            color: #fff;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+    <!-- Header -->
+    <header class="header">
+        <div class="container">
+            <div class="header-container">
+                <div class="logo">
+                    <i class="fas fa-shield-alt"></i>
+                    <span>Ozran Secure Shield</span>
+                </div>
+                <nav class="nav">
+                    <ul>
+                        <li><a href="index.html#features">Features</a></li>
+                        <li><a href="index.html#pricing">Pricing</a></li>
+                        <li><a href="index.html#testimonials">Testimonials</a></li>
+                        <li><a href="about.html">About</a></li>
+                        <li><a href="contact.html">Contact</a></li>
+                    </ul>
+                </nav>
+                <div class="header-actions">
+                    <button class="btn btn-primary" onclick="window.location.href='auth.html'">Login</button>
+                    <button class="mobile-menu-btn" id="mobileMenuBtn">
+                        <i class="fas fa-bars"></i>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <!-- Mobile Navigation Overlay -->
+    <div class="mobile-nav" id="mobileNav">
+        <div class="mobile-nav-header">
+            <div class="logo">
+                <i class="fas fa-shield-alt"></i>
+                <span>Ozran Secure Shield</span>
+            </div>
+            <button class="mobile-nav-close" id="mobileNavClose">
+                <i class="fas fa-times"></i>
+            </button>
+        </div>
+        <ul class="mobile-nav-links">
+            <li><a href="index.html#features" onclick="closeMobileNav()">Features</a></li>
+            <li><a href="index.html#pricing" onclick="closeMobileNav()">Pricing</a></li>
+            <li><a href="index.html#testimonials" onclick="closeMobileNav()">Testimonials</a></li>
+            <li><a href="about.html" onclick="closeMobileNav()">About</a></li>
+            <li><a href="contact.html" onclick="closeMobileNav()">Contact</a></li>
+        </ul>
+        <div class="mobile-nav-cta">
+            <button class="btn btn-primary" onclick="window.location.href='auth.html'">Get Started</button>
+        </div>
+    </div>
+
+    <!-- Contact Content -->
+    <section class="content-page">
+        <div class="container">
+            <div class="page-content">
+                <h1>Contact Us</h1>
+                <div class="contact-details">
+                    <p>Email: <a href="mailto:support@ozransecureshield.com">support@ozransecureshield.com</a></p>
+                    <p>Phone: (555) 123-4567</p>
+                </div>
+                <form class="contact-form">
+                    <input type="text" placeholder="Your Name" required>
+                    <input type="email" placeholder="Your Email" required>
+                    <textarea rows="5" placeholder="Your Message" required></textarea>
+                    <button type="submit">Send Message</button>
+                </form>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer id="contact" class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-section">
+                    <div class="footer-brand">
+                        <div class="logo">
+                            <i class="fas fa-shield-alt"></i>
+                            <span>Ozran Secure Shield</span>
+                        </div>
+                        <p>Protecting organizations worldwide with advanced cybersecurity training, phishing simulation, and comprehensive security awareness programs.</p>
+                        <div class="social-links">
+                            <a href="#" class="social-link"><i class="fab fa-linkedin"></i></a>
+                            <a href="#" class="social-link"><i class="fab fa-twitter"></i></a>
+                            <a href="#" class="social-link"><i class="fab fa-facebook"></i></a>
+                            <a href="#" class="social-link"><i class="fab fa-youtube"></i></a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Product</h4>
+                    <ul class="footer-links">
+                        <li><a href="index.html#features">Features</a></li>
+                        <li><a href="index.html#pricing">Pricing</a></li>
+                        <li><a href="#">Security</a></li>
+                        <li><a href="#">Integrations</a></li>
+                        <li><a href="#">API Documentation</a></li>
+                        <li><a href="#">Roadmap</a></li>
+                    </ul>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Solutions</h4>
+                    <ul class="footer-links">
+                        <li><a href="#">Enterprise</a></li>
+                        <li><a href="#">Small Business</a></li>
+                        <li><a href="#">Healthcare</a></li>
+                        <li><a href="#">Financial Services</a></li>
+                        <li><a href="#">Government</a></li>
+                        <li><a href="#">Education</a></li>
+                    </ul>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Resources</h4>
+                    <ul class="footer-links">
+                        <li><a href="#">Blog</a></li>
+                        <li><a href="#">Case Studies</a></li>
+                        <li><a href="#">Security Center</a></li>
+                        <li><a href="#">Help Center</a></li>
+                        <li><a href="#">Webinars</a></li>
+                        <li><a href="#">Training</a></li>
+                    </ul>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Company</h4>
+                    <ul class="footer-links">
+                        <li><a href="about.html">About Us</a></li>
+                        <li><a href="#">Careers</a></li>
+                        <li><a href="#">Press</a></li>
+                        <li><a href="#">Partners</a></li>
+                        <li><a href="contact.html">Contact</a></li>
+                        <li><a href="#">Events</a></li>
+                    </ul>
+                </div>
+
+                <div class="footer-section">
+                    <h4>Legal</h4>
+                    <ul class="footer-links">
+                        <li><a href="terms.html">Terms of Service</a></li>
+                        <li><a href="privacy.html">Privacy Policy</a></li>
+                        <li><a href="#">Cookie Policy</a></li>
+                        <li><a href="#">GDPR</a></li>
+                        <li><a href="#">Compliance</a></li>
+                        <li><a href="#">Security Policy</a></li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="footer-bottom">
+                <div class="footer-bottom-content">
+                    <p>&copy; 2024 Ozran Secure Shield. All rights reserved.</p>
+                    <div class="footer-bottom-links">
+                        <a href="terms.html">Terms</a>
+                        <a href="privacy.html">Privacy</a>
+                        <a href="about.html">About</a>
+                        <a href="contact.html">Contact</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>
+

--- a/public/index.html
+++ b/public/index.html
@@ -58,7 +58,8 @@
                         <li><a href="#features">Features</a></li>
                         <li><a href="#pricing">Pricing</a></li>
                         <li><a href="#testimonials">Testimonials</a></li>
-                        <li><a href="#contact">Contact</a></li>
+                        <li><a href="about.html">About</a></li>
+                        <li><a href="contact.html">Contact</a></li>
                     </ul>
                 </nav>
                 <div class="header-actions">
@@ -86,7 +87,8 @@
             <li><a href="#features" onclick="closeMobileNav()">Features</a></li>
             <li><a href="#pricing" onclick="closeMobileNav()">Pricing</a></li>
             <li><a href="#testimonials" onclick="closeMobileNav()">Testimonials</a></li>
-            <li><a href="#contact" onclick="closeMobileNav()">Contact</a></li>
+            <li><a href="about.html" onclick="closeMobileNav()">About</a></li>
+            <li><a href="contact.html" onclick="closeMobileNav()">Contact</a></li>
         </ul>
         <div class="mobile-nav-cta">
             <button class="btn btn-primary" onclick="window.location.href='auth.html'">Get Started</button>
@@ -575,11 +577,11 @@
                 <div class="footer-section">
                     <h4>Company</h4>
                     <ul class="footer-links">
-                        <li><a href="#">About Us</a></li>
+                        <li><a href="about.html">About Us</a></li>
                         <li><a href="#">Careers</a></li>
                         <li><a href="#">Press</a></li>
                         <li><a href="#">Partners</a></li>
-                        <li><a href="#">Contact</a></li>
+                        <li><a href="contact.html">Contact</a></li>
                         <li><a href="#">Events</a></li>
                     </ul>
                 </div>
@@ -603,7 +605,8 @@
                     <div class="footer-bottom-links">
                         <a href="terms.html">Terms</a>
                         <a href="privacy.html">Privacy</a>
-                        <a href="#contact">Contact</a>
+                        <a href="about.html">About</a>
+                        <a href="contact.html">Contact</a>
                     </div>
                 </div>
             </div>

--- a/public/sw.js
+++ b/public/sw.js
@@ -13,6 +13,8 @@ const STATIC_FILES = [
     '/dashboard.html',
     '/terms.html',
     '/privacy.html',
+    '/about.html',
+    '/contact.html',
     '/index.css',
     '/auth.css',
     '/dashboard.css',


### PR DESCRIPTION
## Summary
- Create dedicated About and Contact pages using the site's header, footer and styling.
- Add About and Contact navigation links in the homepage header, mobile menu and footer.
- Include the new pages in the service worker's static cache list for offline access.

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_689bb2ef66fc833088de6ad216df0b5e