### PR TITLE
Deduplicate HTML head elements

### DIFF
--- a/public/auth.html
+++ b/public/auth.html
@@ -21,19 +21,13 @@
         <link rel="icon" type="image/x-icon" href="/favicon.ico">
         <link rel="manifest" href="/manifest.json">
         
-        <!-- Your existing CSS links -->
+        <!-- Styles and Fonts -->
         <link rel="stylesheet" href="index.css">
         <link rel="stylesheet" href="auth.css">
-        <!-- ... rest of your existing head content -->
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Login - Ozran Secure Shield</title>
-    <link rel="stylesheet" href="index.css">
-    <link rel="stylesheet" href="auth.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 </head>
 <body class="auth-body">
     <!-- Background Elements -->

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -14,20 +14,14 @@
         <link rel="icon" type="image/x-icon" href="/favicon.ico">
         <link rel="manifest" href="/manifest.json">
         
-        <!-- Your existing CSS links -->
+        <!-- Styles, Fonts, and Scripts -->
         <link rel="stylesheet" href="index.css">
         <link rel="stylesheet" href="dashboard.css">
-        <!-- ... rest of your existing head content -->
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dashboard - Ozran Secure Shield</title>
-    <link rel="stylesheet" href="index.css">
-    <link rel="stylesheet" href="dashboard.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.9.1/chart.min.js"></script>
 </head>
 <body class="dashboard-body">
     <!-- Sidebar -->

--- a/public/index.html
+++ b/public/index.html
@@ -32,17 +32,12 @@
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
         <link rel="manifest" href="/manifest.json">
         
-        <!-- Your existing CSS links stay here -->
+        <!-- Styles and Fonts -->
         <link rel="stylesheet" href="index.css">
-        <!-- ... rest of your existing head content -->
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Ozran Secure Shield - Protect Your Company from Cyber Threats</title>
-    <link rel="stylesheet" href="index.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
 <body>
     <!-- Header -->

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -13,15 +13,10 @@
         <!-- Favicon -->
         <link rel="icon" type="image/x-icon" href="/favicon.ico">
         
-        <!-- Your CSS links -->
+        <!-- Styles -->
         <link rel="stylesheet" href="index.css">
-        <!-- ... rest of your head content -->
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Privacy Policy - Ozran Secure Shield</title>
-    <link rel="stylesheet" href="index.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <style>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+        <style>
         .legal-page {
             padding: 8rem 0 4rem;
             background: var(--bg-primary);

--- a/public/terms.html
+++ b/public/terms.html
@@ -8,12 +8,12 @@
         <!-- SEO Meta Tags -->
         <meta name="description" content="Read Ozran Secure Shield's Terms of Service. Learn about our cybersecurity training platform policies and user agreements.">
         <meta name="robots" content="index, follow">
-        <link rel="canonical" href="https://ozran.net/terms.html">
+        <link rel="canonical" href="https://ozran.net/terms.html" />
 
         <!-- Favicon -->
         <link rel="icon" type="image/x-icon" href="/favicon.ico">
 
-        <!-- Your CSS links -->
+        <!-- Styles -->
         <link rel="stylesheet" href="index.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
         <style>


### PR DESCRIPTION
## Summary
- remove duplicate `<meta>`, `<title>`, favicon, and stylesheet tags in index, auth, dashboard, privacy pages
- ensure terms page uses the correct canonical link

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bb4b24288833088036427cb450c20