### PR TITLE
Add rate limiting to authentication endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.17.1",
+        "express-rate-limit": "^8.0.1",
         "jsonwebtoken": "^9.0.0",
         "nodemailer": "^6.9.5",
         "pg": "^8.10.0"
@@ -524,6 +525,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -733,6 +752,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.17.1",
+    "express-rate-limit": "^8.0.1",
     "jsonwebtoken": "^9.0.0",
     "nodemailer": "^6.9.5",
     "pg": "^8.10.0"

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const cors = require("cors");
 const nodemailer = require("nodemailer");
 const path = require("path");
 const { createClient } = require("@supabase/supabase-js");
+const rateLimit = require("express-rate-limit");
 require("dotenv").config();
 
 const app = express();
@@ -13,6 +14,12 @@ app.use(cors());
 app.use(express.static(path.join(__dirname, "public")));
 
 const SECRET_KEY = process.env.JWT_SECRET || "supersecretkey";
+
+// ✅ Rate Limiter
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,
+});
 
 // ✅ Supabase Setup
 const supabase = createClient(
@@ -44,7 +51,7 @@ app.post("/register", async (req, res) => {
 });
 
 // ✅ Login API
-app.post("/login", async (req, res) => {
+app.post("/login", limiter, async (req, res) => {
   const { email, password } = req.body;
 
   try {
@@ -92,7 +99,7 @@ function authenticateToken(req, res, next) {
 }
 
 // ✅ Send Phishing Test Email API
-app.post("/api/send-test-email", async (req, res) => {
+app.post("/api/send-test-email", limiter, async (req, res) => {
   try {
     const { testerEmail, testEmail } = req.body;
     if (!testerEmail || !testEmail) {


### PR DESCRIPTION
## Summary
- install `express-rate-limit`
- limit `/login` and `/api/send-test-email` to 100 requests per 15 minutes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bb889d6608330b25daace2a84c619