### PR TITLE
Enforce JWT secret requirement and add environment example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Example environment configuration
+# JWT_SECRET is required; the server will throw an error if it is missing
+JWT_SECRET=your_jwt_secret_here
+
+SUPABASE_URL=https://your-supabase-url.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+EMAIL_USER=your-email@example.com
+EMAIL_PASS=your-email-password
+TESTER_EMAIL=alert-recipient@example.com
+
+PORT=10000

--- a/server.js
+++ b/server.js
@@ -12,7 +12,10 @@ app.use(express.json());
 app.use(cors());
 app.use(express.static(path.join(__dirname, "public")));
 
-const SECRET_KEY = process.env.JWT_SECRET || "supersecretkey";
+if (!process.env.JWT_SECRET) {
+  throw new Error("JWT_SECRET environment variable is required");
+}
+const SECRET_KEY = process.env.JWT_SECRET;
 
 // ✅ Supabase Setup
 const supabase = createClient(


### PR DESCRIPTION
## Summary
- Throw an explicit error when `JWT_SECRET` is missing instead of falling back to a default value.
- Provide `.env.example` documenting required environment variables, including `JWT_SECRET`.

## Testing
- `node server.js` *(fails with JWT_SECRET environment variable is required)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bb88a6db08330abe2f03dab9ec8bb