### PR TITLE
Fix JWT cookie parsing for auth status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.49.4",
         "bcryptjs": "^2.4.3",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.17.1",
@@ -332,6 +333,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.49.4",
     "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.17.1",

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require("express");
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
 const cors = require("cors");
+const cookieParser = require("cookie-parser");
 const nodemailer = require("nodemailer");
 const path = require("path");
 const { createClient } = require("@supabase/supabase-js");
@@ -11,6 +12,7 @@ require("dotenv").config();
 const app = express();
 app.set('trust proxy', 1);
 app.use(express.json());
+app.use(cookieParser());
 app.use(cors({ origin: true, credentials: true }));
 // Redirect requests ending with .html to their extensionless counterparts
 app.use((req, res, next) => {
@@ -95,18 +97,6 @@ app.post("/register", async (req, res) => {
   }
 });
 
-// Helper to parse cookies
-function getTokenFromRequest(req) {
-  const cookieHeader = req.headers.cookie;
-  if (!cookieHeader) return null;
-  const cookies = cookieHeader.split(';').reduce((acc, cookie) => {
-    const [name, value] = cookie.trim().split('=');
-    acc[name] = decodeURIComponent(value);
-    return acc;
-  }, {});
-  return cookies.token;
-}
-
 // ✅ Login API
 app.post("/login", limiter, async (req, res) => {
   const { email, password } = req.body;
@@ -159,7 +149,7 @@ app.post("/logout", (req, res) => {
 
 // ✅ Middleware to Verify JWT
 function authenticateToken(req, res, next) {
-  const token = getTokenFromRequest(req);
+  const token = req.cookies.token;
 
   if (!token) return res.sendStatus(401);
 


### PR DESCRIPTION
## Summary
- parse authentication cookie with `cookie-parser`
- include `cookie-parser` dependency

## Testing
- `node server.js` *(fails: no address in use? Wait we had server run; but we must mention we ran with dummy env etc)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689bc6336e4c833082e92d69ec09aeed