### PR TITLE
Respect HTTPS for cookies and document requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Phishing Project Server
+
+This server powers the phishing project application.
+
+## HTTPS Requirement
+
+Production deployments **must** be served over HTTPS. Authentication cookies are marked secure when requests are made over HTTPS or when the `USE_HTTPS=true` environment variable is set. Ensure your deployment uses HTTPS (for example, behind a reverse proxy) to protect these cookies.
+

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.4",

--- a/server.js
+++ b/server.js
@@ -34,6 +34,7 @@ if (!process.env.JWT_SECRET) {
 }
 const SECRET_KEY = process.env.JWT_SECRET;
 
+
 if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
   throw new Error(
     "SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY environment variables are required"
@@ -125,7 +126,7 @@ app.post("/login", limiter, async (req, res) => {
 
     res.cookie("token", token, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === "production",
+      secure: req.secure || process.env.USE_HTTPS === 'true',
       sameSite: "strict",
       maxAge: 60 * 60 * 1000,
     });
@@ -141,7 +142,7 @@ app.post("/login", limiter, async (req, res) => {
 app.post("/logout", (req, res) => {
   res.clearCookie("token", {
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
+    secure: req.secure || process.env.USE_HTTPS === 'true',
     sameSite: "strict",
   });
   res.json({ message: "User logged out successfully" });
@@ -263,4 +264,8 @@ app.get("*", (req, res) => {
 
 // ✅ Start Server
 const PORT = process.env.PORT || 10000;
-app.listen(PORT, () => console.log(`🚀 Server running on port ${PORT}`));
+if (require.main === module) {
+  app.listen(PORT, () => console.log(`🚀 Server running on port ${PORT}`));
+}
+
+module.exports = app;

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const http = require('node:http');
+
+// Set required environment variables before importing the app
+process.env.JWT_SECRET = 'test-secret';
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
+
+const app = require('../server');
+
+function makeRequest(headers = {}) {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(0, () => {
+      const { port } = server.address();
+      const options = {
+        hostname: '127.0.0.1',
+        port,
+        path: '/logout',
+        method: 'POST',
+        headers,
+      };
+
+      const req = http.request(options, (res) => {
+        res.resume();
+        res.on('end', () => {
+          server.close();
+          resolve(res);
+        });
+      });
+
+      req.on('error', (err) => {
+        server.close();
+        reject(err);
+      });
+
+      req.end();
+    });
+  });
+}
+
+test('HTTP request does not set Secure flag', async () => {
+  const res = await makeRequest();
+  const cookie = res.headers['set-cookie'][0] || '';
+  assert.ok(!cookie.includes('Secure'));
+});
+
+test('HTTPS request sets Secure flag', async () => {
+  const res = await makeRequest({ 'X-Forwarded-Proto': 'https' });
+  const cookie = res.headers['set-cookie'][0] || '';
+  assert.ok(cookie.includes('Secure'));
+});
+
+test('USE_HTTPS env forces Secure cookie', async () => {
+  process.env.USE_HTTPS = 'true';
+  const res = await makeRequest();
+  const cookie = res.headers['set-cookie'][0] || '';
+  assert.ok(cookie.includes('Secure'));
+  delete process.env.USE_HTTPS;
+});


### PR DESCRIPTION
## Summary
- Secure authentication cookies based on request security or USE_HTTPS flag
- Document that production deployments must run over HTTPS
- Add integration tests validating cookie security for HTTP and HTTPS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dfbf0e73c833096a07941569b66bb