### PR TITLE
Add configurable CORS whitelist with tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,4 @@ EMAIL_PASS=your-email-password
 TESTER_EMAIL=alert-recipient@example.com
 
 PORT=10000
+CLIENT_URL=https://your-client-url.com

--- a/config.js
+++ b/config.js
@@ -1,0 +1,20 @@
+require('dotenv').config();
+
+const allowedOrigins = (process.env.CLIENT_URL || '')
+  .split(',')
+  .map(origin => origin.trim())
+  .filter(Boolean);
+
+const corsOptions = {
+  origin: (origin, callback) => {
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true);
+    } else {
+      console.warn(`Rejected CORS origin: ${origin}`);
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
+  credentials: true,
+};
+
+module.exports = { allowedOrigins, corsOptions };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "node test/cors.test.js"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.4",

--- a/server.js
+++ b/server.js
@@ -7,13 +7,14 @@ const nodemailer = require("nodemailer");
 const path = require("path");
 const { createClient } = require("@supabase/supabase-js");
 const rateLimit = require("express-rate-limit");
+const { corsOptions } = require("./config");
 require("dotenv").config();
 
 const app = express();
 app.set('trust proxy', 1);
 app.use(express.json());
 app.use(cookieParser());
-app.use(cors({ origin: true, credentials: true }));
+app.use(cors(corsOptions));
 // Redirect requests ending with .html to their extensionless counterparts
 app.use((req, res, next) => {
   if (req.path.endsWith('.html')) {

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -1,0 +1,17 @@
+process.env.CLIENT_URL = 'https://allowed.com';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const { corsOptions, allowedOrigins } = require('../config');
+
+test('allows configured origin', () => {
+  corsOptions.origin(allowedOrigins[0], (err) => {
+    assert.ifError(err);
+  });
+});
+
+test('rejects unexpected origin', () => {
+  corsOptions.origin('https://evil.com', (err) => {
+    assert.ok(err);
+  });
+});


### PR DESCRIPTION
## Summary
- restrict CORS to configured origins via new `config.js`
- document client origin in `.env.example`
- add tests to verify only whitelisted origins are accepted

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dfbf1c09083308bfe099b60f62c82