### PR TITLE
Add environment variable fallbacks and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
 # Example environment configuration
-# JWT_SECRET is required; the server will throw an error if it is missing
+# Dummy values are provided for local development; replace with real secrets in production.
+
+# Secret used to sign JWT tokens
 JWT_SECRET=your_jwt_secret_here
 
+# Supabase project URL and service role key
 SUPABASE_URL=https://your-supabase-url.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Ozran.github.io
+
+Node.js server for the phishing test service.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and adjust the values to suit your environment.
+The server uses the following variables:
+
+- `JWT_SECRET` – secret used to sign JWT tokens. Falls back to a development
+  value if unset, but **must** be provided in production.
+- `SUPABASE_URL` – URL of your Supabase project.
+- `SUPABASE_SERVICE_ROLE_KEY` – Supabase service role key with required permissions.
+- `EMAIL_USER` – email account used to send test emails.
+- `EMAIL_PASS` – password or app password for `EMAIL_USER`.
+- `TESTER_EMAIL` – address that receives phishing alerts.
+- `PORT` – port for the server (defaults to `10000`).
+
+Missing critical variables will produce warnings and, in production, halt the
+server. The default values in `.env.example` are intended for local development
+only.


### PR DESCRIPTION
## Summary
- warn and fallback to development values when JWT or Supabase env vars are missing
- document required env vars in `.env.example` and new README

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689dfbf2da748330893e7e37b5267eda