### PR TITLE
Fix package configuration and Supabase credential handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,42 +1,3 @@
-
-{
-  "name": "phishing-project",
-  "version": "1.0.0",
-  "description": "Automated phishing test service",
-  "main": "server.js",
-
-  "scripts": {
-    "start": "node server.js",
-    "dev": "nodemon server.js",
-    "test": "jest"
-  },
-  "scripts": {
-    "start": "node server.js",
-    "dev": "nodemon server.js",
-    "test": "node --test"
-  },
-  "dependencies": {
-    "@supabase/supabase-js": "^2.49.4",
-    "bcryptjs": "^2.4.3",
-    "cookie-parser": "^1.4.7",
-    "cors": "^2.8.5",
-    "dotenv": "^16.4.7",
-    "express": "^4.17.1",
-    "express-rate-limit": "^8.0.1",
-    "jsonwebtoken": "^9.0.0",
-    "nodemailer": "^6.9.5",
-    "pg": "^8.10.0"
-  },
-  "devDependencies": {
-    "nodemon": "^3.0.1"
-  },
-  "engines": {
-    "node": ">=16"
-  },
-  "author": "Kfir",
-  "license": "MIT"
-}
-
 {
   "name": "phishing-project",
   "version": "1.0.0",
@@ -45,7 +6,9 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node test/cors.test.js"
+    "test": "npm run test:node && npm run test:jest",
+    "test:node": "node --test test/*.test.js",
+    "test:jest": "jest tests"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.4",
@@ -70,3 +33,4 @@
   "author": "Kfir",
   "license": "MIT"
 }
+

--- a/server.js
+++ b/server.js
@@ -44,10 +44,6 @@ if (!SECRET_KEY) {
   SECRET_KEY = "your_jwt_secret_here";
 }
 
-if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
-  throw new Error(
-    "SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY environment variables are required"
-
 let supabaseUrl = process.env.SUPABASE_URL;
 let supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!supabaseUrl || !supabaseServiceRoleKey) {


### PR DESCRIPTION
## Summary
- replace malformed package.json with valid scripts for both Node and Jest tests
- remove stray Supabase credential check so server loads correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e02acc45c8330bd44513a343bd2b2