### PR TITLE
Handle unauthenticated auth-status without 401 errors

### DIFF
--- a/public/auth.js
+++ b/public/auth.js
@@ -20,9 +20,12 @@ async function initializeAuth() {
     try {
         const res = await fetch('/auth-status', { credentials: 'include' });
         if (res.ok) {
-            // Redirect to dashboard if already logged in
-            window.location.href = '/dashboard';
-            return;
+            const data = await res.json();
+            if (data.authenticated) {
+                // Redirect to dashboard if already logged in
+                window.location.href = '/dashboard';
+                return;
+            }
         }
     } catch (error) {
         console.error('Auth status check failed', error);

--- a/public/dashboard.js
+++ b/public/dashboard.js
@@ -42,7 +42,9 @@ function initializeDashboard() {
 async function isAuthenticated() {
     try {
         const res = await fetch('/auth-status', { credentials: 'include' });
-        return res.ok;
+        if (!res.ok) return false;
+        const data = await res.json();
+        return data.authenticated === true;
     } catch (error) {
         console.error('Auth status check failed', error);
         return false;
@@ -612,6 +614,7 @@ async function loadUserData() {
         const res = await fetch('/auth-status', { credentials: 'include' });
         if (!res.ok) return;
         const data = await res.json();
+        if (!data.authenticated) return;
         currentUser = { name: data.user.username, email: data.user.email };
 
         // Update user name in header

--- a/public/index.js
+++ b/public/index.js
@@ -36,7 +36,11 @@ function initializeWebsite() {
 async function checkAuthStatus() {
     try {
         const response = await fetch('/auth-status', { credentials: 'include' });
-        if (response.ok) {
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+        const data = await response.json();
+        if (data.authenticated) {
             // Update login button to show dashboard link
             const loginBtns = document.querySelectorAll('.btn[onclick*="/auth"]');
             loginBtns.forEach(btn => {

--- a/public/script.js
+++ b/public/script.js
@@ -35,7 +35,11 @@ function initializeWebsite() {
 async function checkAuthStatus() {
     try {
         const response = await fetch('/auth-status', { credentials: 'include' });
-        if (response.ok) {
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+        const data = await response.json();
+        if (data.authenticated) {
             // Update login button to show dashboard link
             const loginBtns = document.querySelectorAll('.btn[onclick*="/auth"]');
             loginBtns.forEach(btn => {

--- a/server.js
+++ b/server.js
@@ -182,8 +182,23 @@ function authenticateToken(req, res, next) {
 }
 
 // ✅ Check Authentication Status
-app.get("/auth-status", authenticateToken, (req, res) => {
-  res.json({ authenticated: true, user: { username: req.user.username, email: req.user.email } });
+app.get("/auth-status", (req, res) => {
+  const token = req.cookies.token;
+
+  if (!token) {
+    return res.status(200).json({ authenticated: false });
+  }
+
+  jwt.verify(token, SECRET_KEY, (err, user) => {
+    if (err) {
+      return res.status(200).json({ authenticated: false });
+    }
+
+    res.status(200).json({
+      authenticated: true,
+      user: { username: user.username, email: user.email },
+    });
+  });
 });
 
 // ✅ Send Phishing Test Email API


### PR DESCRIPTION
## Summary
- Return `{ authenticated: false }` with HTTP 200 when no valid token is present
- Check `authenticated` field in client scripts to show dashboard link or redirect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e421427f48330adf396cdd81771e5