### PR TITLE
Ensure logout clears authentication cookie

### DIFF
--- a/server.js
+++ b/server.js
@@ -149,6 +149,7 @@ app.post("/login", limiter, async (req, res) => {
       secure: req.secure || process.env.USE_HTTPS === 'true',
       sameSite: "strict",
       maxAge: 60 * 60 * 1000,
+      path: '/',
     });
 
     res.json({ username: data.username, email: data.email });
@@ -164,8 +165,9 @@ app.post("/logout", (req, res) => {
     httpOnly: true,
     secure: req.secure || process.env.USE_HTTPS === 'true',
     sameSite: "strict",
+    path: '/',
   });
-  res.json({ message: "User logged out successfully" });
+  res.status(200).json({ message: "User logged out successfully" });
 });
 
 // ✅ Middleware to Verify JWT

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -51,10 +51,16 @@ test('HTTPS request sets Secure flag', async () => {
   assert.ok(cookie.includes('Secure'));
 });
 
-test('USE_HTTPS env forces Secure cookie', async () => {
-  process.env.USE_HTTPS = 'true';
-  const res = await makeRequest();
-  const cookie = res.headers['set-cookie'][0] || '';
-  assert.ok(cookie.includes('Secure'));
-  delete process.env.USE_HTTPS;
-});
+  test('USE_HTTPS env forces Secure cookie', async () => {
+    process.env.USE_HTTPS = 'true';
+    const res = await makeRequest();
+    const cookie = res.headers['set-cookie'][0] || '';
+    assert.ok(cookie.includes('Secure'));
+    delete process.env.USE_HTTPS;
+  });
+
+  test('logout cookie clears across all paths', async () => {
+    const res = await makeRequest();
+    const cookie = res.headers['set-cookie'][0] || '';
+    assert.ok(cookie.includes('Path=/'));
+  });


### PR DESCRIPTION
## Summary
- Ensure auth token cookie includes root path and is cleared on logout
- Cover logout cookie path in unit tests

## Testing
- `npm test`
- `npm audit` (fails: 403 Forbidden from npm advisory service)

------
https://chatgpt.com/codex/tasks/task_e_689fe02ecd908330985215cf7c5ddee3