### PR TITLE
feat: support GET logout route

### DIFF
--- a/server.js
+++ b/server.js
@@ -159,8 +159,8 @@ app.post("/login", limiter, async (req, res) => {
   }
 });
 
-// ✅ Logout API (Optional)
-app.post("/logout", (req, res) => {
+// ✅ Logout API (supports POST and GET)
+function handleLogout(req, res) {
   res.clearCookie("token", {
     httpOnly: true,
     secure: req.secure || process.env.USE_HTTPS === 'true',
@@ -168,7 +168,10 @@ app.post("/logout", (req, res) => {
     path: '/',
   });
   res.status(200).json({ message: "User logged out successfully" });
-});
+}
+
+app.post("/logout", handleLogout);
+app.get("/logout", handleLogout);
 
 // ✅ Middleware to Verify JWT
 function authenticateToken(req, res, next) {

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -9,7 +9,7 @@ process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';
 
 const app = require('../server');
 
-function makeRequest(headers = {}) {
+function makeRequest(headers = {}, method = 'POST') {
   return new Promise((resolve, reject) => {
     const server = app.listen(0, () => {
       const { port } = server.address();
@@ -17,7 +17,7 @@ function makeRequest(headers = {}) {
         hostname: '127.0.0.1',
         port,
         path: '/logout',
-        method: 'POST',
+        method,
         headers,
       };
 
@@ -64,3 +64,9 @@ test('HTTPS request sets Secure flag', async () => {
     const cookie = res.headers['set-cookie'][0] || '';
     assert.ok(cookie.includes('Path=/'));
   });
+
+test('GET request also clears cookie', async () => {
+  const res = await makeRequest({}, 'GET');
+  const cookie = res.headers['set-cookie'][0] || '';
+  assert.ok(cookie.includes('Path=/'));
+});


### PR DESCRIPTION
## Summary
- allow logout via GET or POST for easier client integration
- adjust cookie test helper and add coverage for GET /logout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab29d73e888330bf5b18e20e35b2a8